### PR TITLE
Fix on Ubuntu and add features

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ To use it,
 
     % ./xfce4-terminal +
     % ./xfce4-terminal -
+    % ./xfce4-terminal
+    12
+    % ./xfce4-terminal 7.5
 
 In Awesome,
 

--- a/xfce4-terminal-font
+++ b/xfce4-terminal-font
@@ -28,7 +28,12 @@ if __name__ == "__main__":
         from ConfigParser import RawConfigParser  # python2
 
     # read input file
-    f = os.path.join(os.environ["XDG_CONFIG_HOME"], "xfce4", "terminal", "terminalrc")
+    try:
+        f = os.path.join(os.environ["XDG_CONFIG_HOME"], "xfce4", "terminal", "terminalrc")
+    except KeyError:
+        # XDG_CONFIG_HOME environment variable not defined
+        f = os.path.join(os.environ["HOME"], ".config", "xfce4", "terminal", "terminalrc")
+
     c = RawConfigParser()
     c.optionxform = str # make keys case-sensitive
     c.read(f)

--- a/xfce4-terminal-font
+++ b/xfce4-terminal-font
@@ -9,7 +9,8 @@
 #
 # License: GPLv2 or later.
 
-from sys import argv
+from __future__ import print_function
+from sys import argv, exit
 import os
 try:
     from configparser import RawConfigParser  # python3
@@ -18,11 +19,6 @@ except ImportError:
 
 
 if __name__ == '__main__':
-    if len(argv) != 2 or argv[1] not in ['+', '-']:
-        exit('Usage {} +/-'.format(argv[0]))
-
-    delta = int('{}1'.format(argv[1]))
-
     try:
         config_root = os.environ['XDG_CONFIG_HOME']
     except KeyError:
@@ -36,7 +32,21 @@ if __name__ == '__main__':
 
     font, size = config.get('Configuration', 'FontName').split()
 
-    new_size = float(size) + delta
+    if len(argv) == 1:
+        print(size)
+        exit(0)
+
+    elif argv[1] in ['+', '-']:
+        delta = int('{}1'.format(argv[1]))
+        new_size = float(size) + delta
+
+    else:
+        try:
+            new_size = float(argv[1])
+        except ValueError:
+            print('Invalid size', argv[1])
+            exit(1)
+
     config.set('Configuration', 'FontName', '{} {}'.format(font, new_size))
 
     with open(config_file, 'w') as f:

--- a/xfce4-terminal-font
+++ b/xfce4-terminal-font
@@ -5,40 +5,39 @@
 # xfce4-terminal.
 #
 # Copyright © 2013 Noah K. Tilton <noahktilton@gmail.com>
+# Copyright © 2017 Edoardo Negri <edne@gmx.com>
 #
 # License: GPLv2 or later.
 
-# working with xfce4-terminal-0.6.2-1
+from sys import argv
+import os
+try:
+    from configparser import RawConfigParser  # python3
+except ImportError:
+    from ConfigParser import RawConfigParser  # python2
 
-if __name__ == "__main__":
 
-    import sys
+if __name__ == '__main__':
+    if len(argv) != 2 or argv[1] not in ['+', '-']:
+        exit('Usage {} +/-'.format(argv[0]))
 
-    PM = ["+", "-"]
-    if len(sys.argv) != 2 or sys.argv[1] not in PM:
-        sys.exit("Usage {0} {1}".format(sys.argv[0], "/".join(PM)))
+    delta = int('{}1'.format(argv[1]))
 
-    delta = int("{0}1".format(sys.argv[1]))
-
-    import os
     try:
-        from configparser import RawConfigParser  # python3
-    except ImportError:
-        from ConfigParser import RawConfigParser  # python2
-
-    # read input file
-    try:
-        f = os.path.join(os.environ["XDG_CONFIG_HOME"], "xfce4", "terminal", "terminalrc")
+        config_root = os.environ['XDG_CONFIG_HOME']
     except KeyError:
-        # XDG_CONFIG_HOME environment variable not defined
-        f = os.path.join(os.environ["HOME"], ".config", "xfce4", "terminal", "terminalrc")
+        config_root = os.path.join(os.environ['HOME'], '.config')
 
-    c = RawConfigParser()
-    c.optionxform = str # make keys case-sensitive
-    c.read(f)
-    font, size = c.get('Configuration', 'FontName').split()
-    size = float(size) + delta
-    c.set('Configuration', 'FontName', "{0} {1}".format(font, size))
+    config_file = os.path.join(config_root, 'xfce4', 'terminal', 'terminalrc')
 
-    with open(f, 'w') as c_new:
-        c.write(c_new)
+    config = RawConfigParser()
+    config.optionxform = str  # make keys case-sensitive
+    config.read(config_file)
+
+    font, size = config.get('Configuration', 'FontName').split()
+
+    new_size = float(size) + delta
+    config.set('Configuration', 'FontName', '{} {}'.format(font, new_size))
+
+    with open(config_file, 'w') as f:
+        config.write(f)

--- a/xfce4-terminal-font
+++ b/xfce4-terminal-font
@@ -37,8 +37,8 @@ if __name__ == "__main__":
     c.optionxform = str # make keys case-sensitive
     c.read(f)
     font, size = c.get('Configuration', 'FontName').split()
-    size = int(size) + delta
-    c['Configuration']['FontName'] = "{0} {1}".format(font, size)
+    size = float(size) + delta
+    c.set('Configuration', 'FontName', "{0} {1}".format(font, size))
 
     with open(f, 'w') as c_new:
         c.write(c_new)

--- a/xfce4-terminal-font
+++ b/xfce4-terminal-font
@@ -22,7 +22,10 @@ if __name__ == "__main__":
 
     import os
     import re
-    from configparser import RawConfigParser
+    try:
+        from configparser import RawConfigParser  # python3
+    except ImportError:
+        from ConfigParser import RawConfigParser  # python2
 
     # read input file
     f = os.path.join(os.environ["XDG_CONFIG_HOME"], "xfce4", "terminal", "terminalrc")

--- a/xfce4-terminal-font
+++ b/xfce4-terminal-font
@@ -21,7 +21,6 @@ if __name__ == "__main__":
     delta = int("{0}1".format(sys.argv[1]))
 
     import os
-    import re
     try:
         from configparser import RawConfigParser  # python3
     except ImportError:
@@ -37,7 +36,7 @@ if __name__ == "__main__":
     c = RawConfigParser()
     c.optionxform = str # make keys case-sensitive
     c.read(f)
-    font, size = re.search(r'^(.*) (\d+)$', c['Configuration']['FontName']).group(1, 2)
+    font, size = c.get('Configuration', 'FontName').split()
     size = int(size) + delta
     c['Configuration']['FontName'] = "{0} {1}".format(font, size)
 


### PR DESCRIPTION
Now it works on both Python2 and Pyhton3 and on systems where `XDG_CONFIG_HOME` is not defined.
Called without parameters display the actual font size, and with a number as parameter set it as size.