### PR TITLE
let xfce4-terminal-font handle spaced font names

### DIFF
--- a/xfce4-terminal-font
+++ b/xfce4-terminal-font
@@ -30,7 +30,8 @@ if __name__ == '__main__':
     config.optionxform = str  # make keys case-sensitive
     config.read(config_file)
 
-    font, size = config.get('Configuration', 'FontName').split()
+    font = " ".join(config.get('Configuration', 'FontName').split()[:-1])
+    size = config.get('Configuration', 'FontName').split()[-1]
 
     if len(argv) == 1:
         print(size)


### PR DESCRIPTION
In original form the program wasn't able to handle font names with spaces.

`bin/xfce4-terminal-font +
Traceback (most recent call last):
  File "bin/xfce4-terminal-font", line 33, in <module>
    font, size = config.get('Configuration', 'FontName').split()
ValueError: too many values to unpack`

So I introduce the two steps split.

1. pick all but the last field the font name
1.1 concat the created list to a space devided string.
2. pick the last field the font size